### PR TITLE
fix attribute error

### DIFF
--- a/axlearn/cli/utils_test.py
+++ b/axlearn/cli/utils_test.py
@@ -368,7 +368,7 @@ class TestUtils(parameterized.TestCase):
             absl_main(mock_args)
             self.assertEqual(1, len(mock_popen.call_args_list))
             self.assertEqual((expected,), mock_popen.call_args[0])
-            self.assertDictContainsSubset({"text": True}, mock_popen.call_args[1])
+            self.assertTrue({"text": True}.items() <= mock_popen.call_args[1].items())
             self.assertEqual(self.root_module, mock_popen.call_args[1]["env"]["AXLEARN_CLI_NAME"])
 
         shell_cases = [
@@ -397,8 +397,8 @@ class TestUtils(parameterized.TestCase):
                 absl_main(mock_args)
                 self.assertEqual(1, len(mock_popen.call_args_list))
                 self.assertEqual((expected,), mock_popen.call_args[0])
-                self.assertDictContainsSubset(
-                    {"text": True, "shell": True}, mock_popen.call_args[1]
+                self.assertTrue(
+                    {"text": True, "shell": True}.items() <= mock_popen.call_args[1].items()
                 )
                 self.assertEqual(
                     self.root_module, mock_popen.call_args[1]["env"]["AXLEARN_CLI_NAME"]

--- a/axlearn/common/ops/_optimization_barrier.py
+++ b/axlearn/common/ops/_optimization_barrier.py
@@ -94,8 +94,7 @@ def forward_optimization_barrier(pytree: Any) -> Any:
     Returns:
         `pytree` transparently wrapped in an XLA optimization barrier.
     """
-    return ad_checkpoint._optimization_barrier(pytree)  # pylint: disable=protected-access
-
+    return jax.lax.optimization_barrier(pytree)
 
 @forward_optimization_barrier.defjvp
 def forward_optimization_barrier_jvp(primals: tuple, tangents: tuple) -> tuple[Any, Any]:

--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -1017,7 +1017,7 @@ class ContextManagerTest(TestWithTemporaryCWD):
         # With runtime_checks enabled, we should be able to crash with jittable checks without
         # needing to checkify.
         with runtime_checks():
-            with self.assertRaisesRegex(jaxlib.xla_extension.XlaRuntimeError, "cannot be zero!"):
+            with self.assertRaisesRegex(jax.errors.JaxRuntimeError, "cannot be zero!"):
                 jax.jit(f)(0)
 
     def test_prng_impl(self):


### PR DESCRIPTION
1. AttributeError: module 'jax._src.ad_checkpoint' has no attribute '_optimization_barrier'
use [lax.lax.opitmization_barrier](https://github.com/jax-ml/jax/blob/jax-v0.6.2/jax/_src/lax/lax.py#L9000) instead of [jax._src._optimizer_barrier](https://github.com/jax-ml/jax/blob/jax-v0.5.3/jax/_src/ad_checkpoint.py#L940C1-L940C22), which is private property and is removed in 0.6.2

1. AttributeError: 'TestUtils' object has no attribute 'assertDictContainsSubset'. Did you mean: 'assertContainsSubset'
assertDictContainsSubset is removed form unittest lib in python3.12. Replace it with assertTrue --- self.assertDictContainsSubset({"text": True}, mock_popen.call_args[1]) +++ self.assertTrue({"text": True}.items() <= mock_popen.call_args[1].items())

1. AttributeError: module 'jaxlib' has no attribute 'xla_extension'
[change log](https://github.com/jax-ml/jax/blob/1550beedf2f03d50f5d775751aca54c09ccbfa50/CHANGELOG.md?plain=1#L364-L366):

jax.lib.xla_client, the previously-deprecated Device and XlaRuntimeError symbols have been removed; instead use jax.Device and jax.errors.JaxRuntimeError respectively.