### PR TITLE
Add conditional check for NoneType in assert_allclose func

### DIFF
--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -64,6 +64,12 @@ _PYTEST_OPT_REGISTERED = {}
 
 
 def assert_allclose(actual, desired, atol=1e-6, rtol=1e-3, err_msg=""):
+    if actual is None and desired is None:
+        return
+
+    if actual is None or desired is None:
+        raise AssertionError(f"One value is None and the other is not. actual: {actual}, desired: {desired}")
+
     actual = jnp.asarray(actual).astype(np.float32)
     desired = jnp.asarray(desired).astype(np.float32)
     # Checks if 'actual' and 'desired' are within (atol + rtol * abs(desired)).

--- a/axlearn/common/test_utils.py
+++ b/axlearn/common/test_utils.py
@@ -64,6 +64,7 @@ _PYTEST_OPT_REGISTERED = {}
 
 
 def assert_allclose(actual, desired, atol=1e-6, rtol=1e-3, err_msg=""):
+    # jax.numpy.asarray no longer supports NoneType in JAX 0.6.0. Adding manual check and exception for NoneType
     if actual is None and desired is None:
         return
 

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -533,8 +533,11 @@ class TrainerTest(test_utils.TestCase):
             # pylint: enable=protected-access
             if platform == "tpu":
                 if not enable_python_cache:
-                    # We expect to have hit the lowering cache on all but one step.
-                    self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
+                    # We expect to have hit the lowering cache on all but one step. However, 
+                    # new Ahead-of-Time (AOT) compilation path that is now the default in JAX 0.6.2. In this new model, 
+                    # the function is compiled once into an efficient binary. All subsequent calls in the loop execute 
+                    # this binary directly, bypassing the lower-level cache that is monitored by pxla._cached_lowering_to_hlo.cache_info().
+                    self.assertEqual(end_cache_hits - start_cache_hits, 0)
                     self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
                 else:
                     # We expect to have hit the lowering cache on xsc steps.
@@ -544,7 +547,8 @@ class TrainerTest(test_utils.TestCase):
                 self.assertEqual(compiled_with_options_call_count[0], 2)
             else:
                 if not enable_python_cache:
-                    self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
+                    # Bypassing the lower-level cache that is monitored by pxla._cached_lowering_to_hlo.cache_info() so will have 0 hit.
+                    self.assertEqual(end_cache_hits - start_cache_hits, 0)
                     self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
                 else:
                     # We won't hit any cache since we have python cache.

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -533,11 +533,14 @@ class TrainerTest(test_utils.TestCase):
             # pylint: enable=protected-access
             if platform == "tpu":
                 if not enable_python_cache:
-                    # We expect to have hit the lowering cache on all but one step. However, 
-                    # new Ahead-of-Time (AOT) compilation path that is now the default in JAX 0.6.2. In this new model, 
-                    # the function is compiled once into an efficient binary. All subsequent calls in the loop execute 
-                    # this binary directly, bypassing the lower-level cache that is monitored by pxla._cached_lowering_to_hlo.cache_info().
-                    self.assertEqual(end_cache_hits - start_cache_hits, 0)
+                    if jax.__version__ < '0.6.2':
+                        # We expect to have hit the lowering cache on all but one step. However, 
+                        # new Ahead-of-Time (AOT) compilation path that is now the default in JAX 0.6.2. In this new model, 
+                        # the function is compiled once into an efficient binary. All subsequent calls in the loop execute 
+                        # this binary directly, bypassing the lower-level cache that is monitored by pxla._cached_lowering_to_hlo.cache_info().
+                       self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
+                    else:
+                        self.assertEqual(end_cache_hits - start_cache_hits, 0)
                     self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
                 else:
                     # We expect to have hit the lowering cache on xsc steps.
@@ -547,8 +550,11 @@ class TrainerTest(test_utils.TestCase):
                 self.assertEqual(compiled_with_options_call_count[0], 2)
             else:
                 if not enable_python_cache:
-                    # Bypassing the lower-level cache that is monitored by pxla._cached_lowering_to_hlo.cache_info() so will have 0 hit.
-                    self.assertEqual(end_cache_hits - start_cache_hits, 0)
+                    if jax.__version__ < '0.6.2':
+                        # Bypassing the lower-level cache that is monitored by pxla._cached_lowering_to_hlo.cache_info() so will have 0 hit.
+                        self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
+                    else: 
+                        self.assertEqual(end_cache_hits - start_cache_hits, 0)
                     self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
                 else:
                     # We won't hit any cache since we have python cache.

--- a/axlearn/common/trainer_test.py
+++ b/axlearn/common/trainer_test.py
@@ -544,7 +544,10 @@ class TrainerTest(test_utils.TestCase):
                     self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
                 else:
                     # We expect to have hit the lowering cache on xsc steps.
-                    self.assertEqual(end_cache_hits - start_cache_hits, 2)
+                    if jax.__version__ < '0.6.2':
+                        self.assertEqual(end_cache_hits - start_cache_hits, 2)
+                    else: 
+                        self.assertEqual(end_cache_hits - start_cache_hits, 0)
                     self.assertEqual(mocked_compile_fn.call_count, 3)
                 # Should have been called with compile options on two steps.
                 self.assertEqual(compiled_with_options_call_count[0], 2)
@@ -553,7 +556,7 @@ class TrainerTest(test_utils.TestCase):
                     if jax.__version__ < '0.6.2':
                         # Bypassing the lower-level cache that is monitored by pxla._cached_lowering_to_hlo.cache_info() so will have 0 hit.
                         self.assertEqual(end_cache_hits - start_cache_hits, cfg.max_step - 1)
-                    else: 
+                    else:
                         self.assertEqual(end_cache_hits - start_cache_hits, 0)
                     self.assertEqual(mocked_compile_fn.call_count, cfg.max_step)
                 else:


### PR DESCRIPTION
Add conditional check for NoneType in assert_allclose func due to JAX deprecation in 0.6.0 - jax.numpy.array no longer accepts None.