### PR TITLE
Backport fix in the PR #4

### DIFF
--- a/axlearn/common/utils_test.py
+++ b/axlearn/common/utils_test.py
@@ -146,7 +146,7 @@ class TreeUtilsTest(TestCase):
         class MyEnum(str, enum.Enum):
             RED = "red"
 
-        self.assertEqual({MyEnum.RED: "red"}, tree_paths({MyEnum.RED: 3}))
+        self.assertEqual({MyEnum.RED: "MyEnum.RED"}, tree_paths({MyEnum.RED: 3}))
 
         # With is_leaf set.
         self.assertEqual(


### PR DESCRIPTION
1. Change the assertion from the value of the enum to the key which is affected by the Python upgrade


We've conducted a simple test with following code which is the same as what the `Axlearn` uses:
```
import enum
import jax
from jax._src.tree_util import KeyEntry

class MyEnum(str, enum.Enum):
    RED = "red"

def _key_entry_to_str(key_entry: KeyEntry) -> str:
    # Although (e.g.) DictKey does have its own __str__ implementation, calling
    # str(DictKey('a')) produces "['a']" instead of just "a".
    if isinstance(key_entry, jax.tree_util.DictKey):
        key = key_entry.key
    elif isinstance(key_entry, jax.tree_util.GetAttrKey):
        key = key_entry.name
    elif isinstance(key_entry, jax.tree_util.SequenceKey):
        key = key_entry.idx
    elif isinstance(key_entry, jax.tree_util.FlattenedIndexKey):
        key = key_entry.key
    else:
        raise RuntimeError(f"Unknown key entry type {type(key_entry)}: {key_entry}.")

    # Use f-string instead of calling str() because it matches the behavior of the previous
    # implementation and differs from str() for (e.g.) enums.
    return f"{key}"

def testfn():
    tree = {MyEnum.RED: 'red'}
    new_tree = jax.tree.map_with_path(
        lambda kp, _: "/".join(_key_entry_to_str(k) for k in kp), tree, is_leaf=None
    )
    print(new_tree)

if __name__ == "__main__":
    testfn()
```

and the lib versions were set to the same except versions of Python itself:
```
Package    Version
---------- -------
jax        0.6.2
jaxlib     0.6.2
ml_dtypes  0.5.3
numpy      2.2.6
opt_einsum 3.4.0
pip        25.2
scipy      1.15.3
```

The output were:
Python 3.10: ```{<MyEnum.RED: 'red'>: 'red'}```
Python 3.12:```{<MyEnum.RED: 'red'>: 'MyEnum.RED'}```

Therefore, we suggest a change of the test case accordingly.